### PR TITLE
日本語のロケールを使用するよう修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ RUN gpg --keyserver pgp.mit.edu --recv-keys \
 
 RUN yum -y install postgresql-server; yum clean all; chkconfig postgresql on
 
-ENV LANG en_US.utf8
+RUN localedef -i ja_JP -c -f UTF-8 -A /usr/share/locale/locale.alias ja_JP.UTF-8
+ENV LANG ja_JP.UTF-8
 
 RUN mkdir /docker-entrypoint-initdb.d
 


### PR DESCRIPTION
`LANG en_US.utf8` の場合、日本語文字のソートに不具合が生じるため